### PR TITLE
[feature] SVG 파싱 후 렌더링

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,20 @@
+import { menus } from "./stories/assets/datas/datas";
+import HeaderMenuBar from "./stories/layouts/HeaderMenuBar/HeaderMenuBar";
+import Iconbar from "./stories/layouts/Iconbar/Iconbar";
+import Canvas from "./stories/layouts/Canvas/Canvas";
+import Panel from "./stories/layouts/Panel/Panel";
+import "./style.scss";
+
 function App() {
   return (
     <>
+      <HeaderMenuBar menus={menus} />
+      <main className="main">
+        <Iconbar toolbar={true} />
+        <Canvas width={300} height={300} active={true} />
+        <Iconbar toolbar={false} active={true} />
+      </main>
+      <Panel />
     </>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,35 @@
-import { menus } from "./stories/assets/datas/datas";
 import HeaderMenuBar from "./stories/layouts/HeaderMenuBar/HeaderMenuBar";
 import Iconbar from "./stories/layouts/Iconbar/Iconbar";
 import Canvas from "./stories/layouts/Canvas/Canvas";
 import Panel from "./stories/layouts/Panel/Panel";
+import HiddenFileInput from "./components/HiddenFileInput";
+import { useFileUpload } from "./hooks/useFileUpload";
+import { useMenus } from "./hooks/useMenus";
 import "./style.scss";
 
 function App() {
+  const {
+    hiddenFileInputRef,
+    onFileChange,
+    triggerFileDialog
+  } = useFileUpload();
+
+  const menus = useMenus(triggerFileDialog);
+
   return (
     <>
       <HeaderMenuBar menus={menus} />
       <main className="main">
         <Iconbar toolbar={true} />
-        <Canvas width={300} height={300} active={true} />
+        <Canvas active={true} />
         <Iconbar toolbar={false} active={true} />
       </main>
       <Panel />
+      <HiddenFileInput
+        fileInputRef={hiddenFileInputRef}
+        onChange={onFileChange}
+        accept=".svg"
+      />
     </>
   );
 }

--- a/src/components/HiddenFileInput.tsx
+++ b/src/components/HiddenFileInput.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+
+interface HiddenFileInputProps {
+  fileInputRef: React.RefObject<HTMLInputElement | null>;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  accept?: string;
+}
+
+const HiddenFileInput: React.FC<HiddenFileInputProps> = ({
+   fileInputRef,
+   onChange,
+   accept = ".svg",
+ }) => {
+  return (
+    <input
+      type="file"
+      ref={fileInputRef}
+      accept={accept}
+      style={{ display: "none" }}
+      onChange={onChange}
+    />
+  );
+};
+
+export default HiddenFileInput;

--- a/src/hooks/useFileUpload.ts
+++ b/src/hooks/useFileUpload.ts
@@ -13,7 +13,7 @@ export const useFileUpload = () => {
 
   const onFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFile = event.target.files?.[0];
-    if (!selectedFile || !selectedFile.name.endsWith(".svg")) return;
+    if (!selectedFile || !selectedFile.name.endsWith(".svg") || selectedFile.type !== "image/svg+xml") return;
 
     const reader = new FileReader();
     reader.onload = () => {

--- a/src/hooks/useFileUpload.ts
+++ b/src/hooks/useFileUpload.ts
@@ -50,9 +50,13 @@ export const useFileUpload = () => {
               canvasWidth = parseFloat(widthAttr);
               canvasHeight = parseFloat(heightAttr);
             } else if (viewBox) {
-              const [, , viewBoxWidth, viewBoxHeight] = viewBox.split(" ").map(Number);
-              canvasWidth = viewBoxWidth;
-              canvasHeight = viewBoxHeight;
+              const viewBoxValues = viewBox.split(" ").map(Number);
+
+              if (viewBoxValues.length === 4 && viewBoxValues.every(val => !isNaN(val))) {
+                const [, , viewBoxWidth, viewBoxHeight] = viewBoxValues;
+                canvasWidth = viewBoxWidth;
+                canvasHeight = viewBoxHeight;
+              }
             }
 
             if (!isNaN(canvasWidth) && !isNaN(canvasHeight)) {

--- a/src/hooks/useFileUpload.ts
+++ b/src/hooks/useFileUpload.ts
@@ -1,5 +1,5 @@
 import { useRef } from "react";
-import { useSvgStore } from "../stores/svgStore";
+import { type SvgElement, useSvgStore } from "../stores/svgStore";
 
 export const useFileUpload = () => {
   const hiddenFileInputRef = useRef<HTMLInputElement | null>(null);
@@ -46,7 +46,7 @@ export const useFileUpload = () => {
             updateCanvasSize(canvasWidth, canvasHeight);
           }
 
-          const elements: any[] = [];
+          const elements: SvgElement[] = [];
           const supportedTags = [
             "path", "rect", "circle", "ellipse",
             "line", "polygon", "polyline", "g"
@@ -54,14 +54,14 @@ export const useFileUpload = () => {
 
           supportedTags.forEach((tag) => {
             svgDocument.querySelectorAll(tag).forEach((el) => {
-              const attrs: Record<string, string> = {};
+              const attributes: Record<string, string> = {};
               Array.from(el.attributes).forEach(attr => {
-                attrs[attr.name] = attr.value;
+                attributes[attr.name] = attr.value;
               });
 
               elements.push({
                 tag,
-                attributes: attrs,
+                attributes,
               });
             });
           });

--- a/src/hooks/useFileUpload.ts
+++ b/src/hooks/useFileUpload.ts
@@ -1,0 +1,59 @@
+import { useRef } from "react";
+import { useSvgStore } from "../stores/svgStore";
+
+export const useFileUpload = () => {
+  const hiddenFileInputRef = useRef<HTMLInputElement | null>(null);
+  const updateSvgContent = useSvgStore((state) => state.setSvgContent);
+  const updateCanvasSize = useSvgStore((state) => state.setCanvasSize);
+
+  const triggerFileDialog = () => {
+    hiddenFileInputRef.current?.click();
+  };
+
+  const onFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFile = event.target.files?.[0];
+    if (!selectedFile || !selectedFile.name.endsWith(".svg")) return;
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result === "string") {
+        const svgString = reader.result;
+        updateSvgContent(svgString);
+
+        const parser = new DOMParser();
+        const svgDocument = parser.parseFromString(svgString, "image/svg+xml");
+        const svgElement = svgDocument.querySelector("svg");
+
+        if (svgElement) {
+          const viewBox = svgElement.getAttribute("viewBox");
+          const widthAttr = svgElement.getAttribute("width");
+          const heightAttr = svgElement.getAttribute("height");
+
+          let canvasWidth = 500;
+          let canvasHeight = 500;
+
+          if (widthAttr && heightAttr) {
+            canvasWidth = parseFloat(widthAttr);
+            canvasHeight = parseFloat(heightAttr);
+          } else if (viewBox) {
+            const [, , viewBoxWidth, viewBoxHeight] = viewBox.split(" ").map(Number);
+            canvasWidth = viewBoxWidth;
+            canvasHeight = viewBoxHeight;
+          }
+
+          if (!isNaN(canvasWidth) && !isNaN(canvasHeight)) {
+            updateCanvasSize(canvasWidth, canvasHeight);
+          }
+        }
+      }
+    };
+
+    reader.readAsText(selectedFile);
+  };
+
+  return {
+    hiddenFileInputRef,
+    onFileChange,
+    triggerFileDialog,
+  };
+};

--- a/src/hooks/useFileUpload.ts
+++ b/src/hooks/useFileUpload.ts
@@ -5,6 +5,7 @@ export const useFileUpload = () => {
   const hiddenFileInputRef = useRef<HTMLInputElement | null>(null);
   const updateSvgContent = useSvgStore((state) => state.setSvgContent);
   const updateCanvasSize = useSvgStore((state) => state.setCanvasSize);
+  const updateSvgElements = useSvgStore((state) => state.setSvgElements);
 
   const triggerFileDialog = () => {
     hiddenFileInputRef.current?.click();
@@ -44,6 +45,28 @@ export const useFileUpload = () => {
           if (!isNaN(canvasWidth) && !isNaN(canvasHeight)) {
             updateCanvasSize(canvasWidth, canvasHeight);
           }
+
+          const elements: any[] = [];
+          const supportedTags = [
+            "path", "rect", "circle", "ellipse",
+            "line", "polygon", "polyline", "g"
+          ];
+
+          supportedTags.forEach((tag) => {
+            svgDocument.querySelectorAll(tag).forEach((el) => {
+              const attrs: Record<string, string> = {};
+              Array.from(el.attributes).forEach(attr => {
+                attrs[attr.name] = attr.value;
+              });
+
+              elements.push({
+                tag,
+                attributes: attrs,
+              });
+            });
+          });
+
+          updateSvgElements(elements);
         }
       }
     };

--- a/src/hooks/useMenus.ts
+++ b/src/hooks/useMenus.ts
@@ -1,0 +1,19 @@
+import { menus as initialMenus } from "../stories/assets/datas/datas";
+
+export const useMenus = (onOpenFile: () => void) => {
+  const menus = initialMenus.map((menu) => {
+    if (menu.name === "File") {
+      return {
+        ...menu,
+        onSelect: (value: string) => {
+          if (value === "open") {
+            onOpenFile();
+          }
+        },
+      };
+    }
+    return menu;
+  });
+
+  return menus;
+};

--- a/src/stores/svgStore.ts
+++ b/src/stores/svgStore.ts
@@ -1,17 +1,26 @@
 import { create } from "zustand";
 
+interface SvgElement {
+  tag: string;
+  attributes: Record<string, string>;
+}
+
 interface SvgState {
   svgContent: string | null;
   canvasWidth: number;
   canvasHeight: number;
+  svgElements: SvgElement[];
   setSvgContent: (content: string) => void;
   setCanvasSize: (width: number, height: number) => void;
+  setSvgElements: (elements: SvgElement[]) => void;
 }
 
 export const useSvgStore = create<SvgState>((set) => ({
   svgContent: null,
   canvasWidth: 500,
   canvasHeight: 500,
+  svgElements: [],
   setSvgContent: (content) => set({ svgContent: content }),
   setCanvasSize: (width, height) => set({ canvasWidth: width, canvasHeight: height }),
+  setSvgElements: (elements) => set({ svgElements: elements }),
 }));

--- a/src/stores/svgStore.ts
+++ b/src/stores/svgStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 
-interface SvgElement {
+export interface SvgElement {
   tag: string;
   attributes: Record<string, string>;
 }

--- a/src/stores/svgStore.ts
+++ b/src/stores/svgStore.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+
+interface SvgState {
+  svgContent: string | null;
+  canvasWidth: number;
+  canvasHeight: number;
+  setSvgContent: (content: string) => void;
+  setCanvasSize: (width: number, height: number) => void;
+}
+
+export const useSvgStore = create<SvgState>((set) => ({
+  svgContent: null,
+  canvasWidth: 500,
+  canvasHeight: 500,
+  setSvgContent: (content) => set({ svgContent: content }),
+  setCanvasSize: (width, height) => set({ canvasWidth: width, canvasHeight: height }),
+}));

--- a/src/stories/layouts/Canvas/Canvas.tsx
+++ b/src/stories/layouts/Canvas/Canvas.tsx
@@ -1,23 +1,30 @@
 import type { CanvasProps } from "./Canvas.types";
+import { useEffect, useRef } from "react";
+import { SVG } from "@svgdotjs/svg.js";
+import { useSvgStore } from "../../../stores/svgStore";
 import styles from "../../styles/layouts/Canvas/Canvas.module.scss";
 
-export default function Canvas({
-   width,
-   height,
-   active,
-   children
-  }: CanvasProps) {
+export default function Canvas({ active }: CanvasProps) {
+  const canvasRef = useRef<HTMLDivElement>(null);
+  const svgContent = useSvgStore((state) => state.svgContent);
+  const width = useSvgStore((state) => state.canvasWidth);
+  const height = useSvgStore((state) => state.canvasHeight);
+
+  useEffect(() => {
+    if (canvasRef.current && svgContent) {
+      canvasRef.current.innerHTML = "";
+      const draw = SVG().addTo(canvasRef.current).size(width, height);
+      draw.svg(svgContent);
+    }
+  }, [svgContent, width, height]);
+
   return (
-    <div className={`
-      ${styles["canvas"]}
-      ${active ? styles["active"] : ""}
-    `}>
+    <div className={`${styles["canvas"]} ${active ? styles["active"] : ""}`}>
       <div
         className={styles["canvas-editor"]}
         style={{ width: `${width}px`, height: `${height}px` }}
-      >
-        {children}
-      </div>
+        ref={canvasRef}
+      />
     </div>
   );
 }

--- a/src/stories/layouts/Canvas/Canvas.tsx
+++ b/src/stories/layouts/Canvas/Canvas.tsx
@@ -12,9 +12,16 @@ export default function Canvas({ active }: CanvasProps) {
 
   useEffect(() => {
     if (canvasRef.current && svgContent) {
-      canvasRef.current.innerHTML = "";
-      const draw = SVG().addTo(canvasRef.current).size(width, height);
-      draw.svg(svgContent);
+      try {
+        while (canvasRef.current.firstChild) {
+          canvasRef.current.removeChild(canvasRef.current.firstChild);
+        }
+
+        const draw = SVG().addTo(canvasRef.current).size(width, height);
+        draw.svg(svgContent);
+      } catch (error) {
+        console.error("SVG 렌더링 중 오류 발생:", error);
+      }
     }
   }, [svgContent, width, height]);
 

--- a/src/stories/layouts/Canvas/Canvas.types.ts
+++ b/src/stories/layouts/Canvas/Canvas.types.ts
@@ -1,8 +1,3 @@
-import React from "react";
-
 export type CanvasProps = {
-  width: number,
-  height: number,
-  active: boolean,
-  children?: React.ReactNode
+  active: boolean;
 };


### PR DESCRIPTION
# 작업 상세 내용

- [x] SVG 내부의 각 요소에 존재하는 속성을 탐색하여 저장한다.
- [x] 업로드된 SVG 파일을 XML DOM으로 파싱한다.

---

# 기능

- 요소들의 속성 정보를 정확히 파악하고 상태로 보관한다.
- 업로드된 SVG 파일을 FileReader를 통해 문자열로 변환한 후, DOMParser를 사용해 XML DOM으로 파싱한다.

---

# 예상 결과

- 사용자가 업로드한 SVG 파일을 기반으로, 편집기에서 SVG를 시각적으로 보여준다.

---

# 기간

- **시작일** 2025. 06. 07
- **종료일** 미정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- SVG 파일 업로드 기능이 추가되어 사용자가 .svg 파일을 불러올 수 있습니다.
	- 동적으로 메뉴와 툴바, 패널, 캔버스 등 멀티파트 UI 레이아웃이 도입되었습니다.
- **Refactor**
	- 캔버스 컴포넌트가 외부 상태를 기반으로 SVG를 렌더링하도록 개선되었습니다.
- **Bug Fixes**
	- SVG 파일의 크기 및 요소 정보가 정확하게 추출되어 캔버스에 반영됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->